### PR TITLE
Build fix: remove references to pwd.h and utime.h for nuttx build.

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -52,7 +52,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <limits.h> /* INT_MAX, PATH_MAX, IOV_MAX */
-#if !defined(__TIZENRT__)
+#if !defined(__TIZENRT__) && !defined(__NUTTX__)
 # include <sys/uio.h> /* writev */
 # include <pwd.h>
 #endif

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -54,7 +54,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#if !defined(__TIZENRT__)
+#if !defined(__TIZENRT__) && !defined(__NUTTX__)
 # include <sys/uio.h> /* writev */
 # include <utime.h>
 #endif


### PR DESCRIPTION
Building libtuv against nuttx in freestanding environment ends up with error due to missing pwd.h and utime.h.
This PR fixes the issue by excluding the inclusions (same as TizenRT).

libtuv-DCO-1.0-Signed-off-by: Tomasz Wozniak t.wozniak@samsung.com